### PR TITLE
Fix README URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # The Library of Shannon
 The Library of Shannon is a near-infinite library of books whose content is randomly generated in a way that approximates natural written English. 
-It is a spin on Jorge Luis Borges' novella 'The Library of Babel'. It is inspired by Jonathan Basile's virtual rendition of the library (libraryofbable.info) and Claude Shannon's book 'The Mathematical Theory of Communication'.
+It is a spin on Jorge Luis Borges' novella 'The Library of Babel'. It is inspired by Jonathan Basile's virtual rendition of the library (libraryofbabel.info) and Claude Shannon's book 'The Mathematical Theory of Communication'.


### PR DESCRIPTION
## Summary
- correct a typo in README URL linking to libraryofbabel.info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400aad14208330bf9b72457e0a2a9c