### PR TITLE
Fix random index error

### DIFF
--- a/app.py
+++ b/app.py
@@ -284,8 +284,8 @@ async def construct_markov_sentence(websocket: WebSocket):
         while not word_found:
             if state['stop_requested']:
                 return
-            index = params['rand'].randint(0, len(text) - state['curr_order_of_approx'])
             if state['curr_order_of_approx'] > 1:
+                index = params['rand'].randint(0, len(text) - state['curr_order_of_approx'])
                 new_words = {}
                 for i in range(state['curr_order_of_approx'] - 1):
                     new_words[i] = text[index + i]
@@ -326,6 +326,7 @@ async def construct_markov_sentence(websocket: WebSocket):
                     break
 
             elif state['curr_order_of_approx'] == 1:
+                index = params['rand'].randint(0, len(text) - 2)
                 word = text[index]
                 if word[-1] in params['sentence_enders']: 
                     new_word = text[index + 1]


### PR DESCRIPTION
## Summary
- avoid out-of-bounds index lookups when generating markov sentences

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840098dbda483309e072e049d6acb90